### PR TITLE
Add independent code review validation to architect plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "architect",
       "source": "./architect",
-      "description": "AI Architect with 6-phase parallel execution planning and quality gates"
+      "description": "AI Architect with 7-phase workflow: parallel execution, quality gates, and independent code review validation"
     },
     {
       "name": "issuify",

--- a/architect/.claude-plugin/plugin.json
+++ b/architect/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "architect",
-  "description": "AI Architect & System Orchestrator for complex engineering projects with parallel execution and quality gates",
-  "version": "1.0.0",
+  "description": "AI Architect & System Orchestrator for complex engineering projects with parallel execution, quality gates, and independent code review validation",
+  "version": "1.1.0",
   "author": {
     "name": "Headlands"
   }

--- a/architect/README.md
+++ b/architect/README.md
@@ -1,6 +1,6 @@
 # Architect Plugin
 
-AI Architect & System Orchestrator for managing complex engineering projects with parallel execution and quality gates.
+AI Architect & System Orchestrator for managing complex engineering projects with parallel execution, quality gates, and independent code review validation.
 
 ## Installation
 
@@ -14,7 +14,7 @@ AI Architect & System Orchestrator for managing complex engineering projects wit
 /architect <your complex engineering goal>
 ```
 
-## The 6-Phase Workflow
+## The 7-Phase Workflow
 
 ### Phase 1: Deconstruct the Goal
 The architect breaks down your high-level request into core engineering objectives and restates the mission for confirmation.
@@ -55,10 +55,33 @@ Creates a `PLAN.md` file with:
   - Approves or creates fix-it tasks
   - Never proceeds until all tasks pass
 
-### Phase 6: Final Integration & Report
+### Phase 6: Independent Validation *(New)*
+After implementation completes, spawns an **independent code reviewer** with fresh context:
+
+1. **Discover Guidelines**: Searches for project-specific review criteria (`code-review-guidelines.md`, `AGENTS.md`, `CONTRIBUTING.md`, etc.)
+2. **Generate Change Summary**: Creates neutral diff without explaining intent
+3. **Spawn Reviewer**: Launches a fresh task that receives ONLY:
+   - The code diff (no context about goals)
+   - Generic review criteria (security, reliability, quality)
+   - Any discovered project-specific guidelines
+4. **Triage Issues**: Categorizes by severity (P0-P3)
+5. **Fix & Repeat**: Addresses P0/P1 issues, repeats until clean
+
+**Why this matters:**
+- Eliminates confirmation bias (reviewer doesn't know intended behavior)
+- Catches issues the implementation-aware architect might rationalize
+- Respects project-specific conventions automatically
+- Maximum 3 cycles before escalating unresolved issues
+
+### Phase 7: Final Integration & Report
 - Performs final integration test
+- Runs project linters/tests
 - Deletes PLAN.md
-- Provides comprehensive final report
+- Provides comprehensive report including:
+  - Work completed
+  - Issues found and fixed during validation
+  - Any documented exceptions
+  - Final codebase state
 
 ## When to Use
 
@@ -68,6 +91,7 @@ Creates a `PLAN.md` file with:
 - Complex migrations (database, API, framework)
 - Projects needing explicit quality checkpoints
 - Work requiring clear scope boundaries
+- Codebases with review guidelines you want enforced
 
 **Not ideal for:**
 - Single-file changes
@@ -87,7 +111,8 @@ The architect will:
 2. Plan migration steps (schema, API, client)
 3. Get your approval on the approach
 4. Execute with quality gates at each phase
-5. Verify integration tests pass
+5. Run independent validation to catch security issues
+6. Verify integration tests pass
 
 ### Multi-Service Refactoring
 ```bash
@@ -99,7 +124,8 @@ The architect will:
 2. Plan service boundaries and APIs
 3. Review with you before changes
 4. Implement with parallel tasks
-5. Test end-to-end integration
+5. Validate changes independently for security/reliability
+6. Test end-to-end integration
 
 ## Tips
 
@@ -124,14 +150,30 @@ During execution you'll see:
 - **PLAN.md** - The complete execution plan (deleted after completion)
 - **Task outputs** - Results from parallel research and implementation
 - **Quality reports** - Reviews of each completed task
+- **Validation reports** - Independent review findings and fixes
 - **Final report** - Summary of all work done
+
+## How Review Guidelines Are Discovered
+
+The validation phase automatically searches for these files (in priority order):
+- `**/code-review-guidelines.md`
+- `**/code-review*.md`
+- `**/review-guidelines*.md`
+- `**/AGENTS.md`
+- `**/CLAUDE.md`
+- `**/CONTRIBUTING.md`
+- `**/CODE_STYLE.md`
+- `**/.github/PULL_REQUEST_TEMPLATE*`
+
+If found, these are provided to the reviewer alongside generic criteria.
 
 ## Configuration
 
 No configuration needed. The architect uses:
 - Task tool for parallel execution
-- Model switching (Haiku for research, Opus for review)
+- Model switching (Haiku for research, Opus for review/validation)
 - Your existing development tools and test infrastructure
+- Auto-discovered review guidelines
 
 ## Limitations
 
@@ -139,6 +181,7 @@ No configuration needed. The architect uses:
 - Works best with existing test suites
 - Needs clear success criteria for quality gates
 - Human approval adds time (but prevents mistakes)
+- Validation limited to 3 cycles before escalation
 
 ## Support
 


### PR DESCRIPTION
## Summary

- Add Phase 6 (Independent Validation) between implementation and final report
- Reviewer spawns with only the diff—no knowledge of the plan or goals
- Auto-discovers project guidelines (`code-review-guidelines.md`, `AGENTS.md`, etc.)
- Version bump to 1.1.0

## Why

Fixes #1. Eliminates confirmation bias by having a blind reviewer catch issues purely on code quality.

## Test plan

- [ ] Run `/architect` on a task that introduces a subtle bug—verify the validation phase catches it
- [ ] Test with a repo that has `code-review-guidelines.md`—verify guidelines get included
- [ ] Confirm Phase 7 (final report) mentions validation findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)